### PR TITLE
fix(datasource-cosmos): increase maxConditions default to 1000

### DIFF
--- a/packages/datasource-cosmos/src/collection.ts
+++ b/packages/datasource-cosmos/src/collection.ts
@@ -35,6 +35,7 @@ export default class CosmosCollection extends BaseCollection {
     model: ModelCosmos,
     logger: Logger,
     nativeDriver: CosmosClient,
+    options?: { maxConditions?: number },
   ) {
     if (!model) throw new Error('Invalid (null) model instance.');
 
@@ -53,6 +54,7 @@ export default class CosmosCollection extends BaseCollection {
       validationOptions: {
         // Allow unknown fields since schema might not include all nested paths
         allowUnknownFields: true,
+        maxConditions: options?.maxConditions,
       },
     });
 

--- a/packages/datasource-cosmos/src/datasource.ts
+++ b/packages/datasource-cosmos/src/datasource.ts
@@ -19,7 +19,7 @@ export default class CosmosDataSource extends BaseDataSource<CosmosCollection> {
     cosmosClient: CosmosClient,
     collectionModels: ModelCosmos[],
     logger: Logger,
-    options?: { liveQueryConnections?: string; liveQueryDatabase?: string },
+    options?: { liveQueryConnections?: string; liveQueryDatabase?: string; maxConditions?: number },
   ) {
     super();
 
@@ -27,7 +27,7 @@ export default class CosmosDataSource extends BaseDataSource<CosmosCollection> {
     this.cosmosClient = cosmosClient;
 
     // Creating collections
-    this.createCollections(collectionModels, logger);
+    this.createCollections(collectionModels, logger, options?.maxConditions);
 
     if (options?.liveQueryConnections && options?.liveQueryDatabase) {
       this.addNativeQueryConnection(options.liveQueryConnections, {
@@ -39,12 +39,18 @@ export default class CosmosDataSource extends BaseDataSource<CosmosCollection> {
     logger?.('Info', 'CosmosDataSource - Built');
   }
 
-  protected async createCollections(collectionModels: ModelCosmos[], logger: Logger) {
+  protected async createCollections(
+    collectionModels: ModelCosmos[],
+    logger: Logger,
+    maxConditions?: number,
+  ) {
     collectionModels
       // avoid schema reordering
       .sort((modelA, modelB) => (modelA.name > modelB.name ? 1 : -1))
       .forEach(model => {
-        const collection = new CosmosCollection(this, model, logger, this.cosmosClient);
+        const collection = new CosmosCollection(this, model, logger, this.cosmosClient, {
+          maxConditions,
+        });
         this.addCollection(collection);
       });
   }

--- a/packages/datasource-cosmos/src/index.ts
+++ b/packages/datasource-cosmos/src/index.ts
@@ -184,6 +184,12 @@ export function createCosmosDataSource(
      * Default: false
      */
     logQueries?: boolean;
+    /**
+     * Maximum number of conditions allowed in a single query condition tree
+     * Increase this if you use charts with many time buckets or complex filters
+     * Default: 1000
+     */
+    maxConditions?: number;
   },
 ): DataSourceFactory {
   return async (logger: Logger) => {
@@ -203,6 +209,7 @@ export function createCosmosDataSource(
       schema,
       logRuConsumption,
       logQueries,
+      maxConditions,
     } = options || {};
 
     // Configure RU logging if enabled
@@ -263,6 +270,7 @@ export function createCosmosDataSource(
     const datasource = new CosmosDataSource(client, collectionModels, logger, {
       liveQueryConnections,
       liveQueryDatabase,
+      maxConditions,
     });
 
     // Add virtual array collections if specified

--- a/packages/datasource-cosmos/src/utils/query-validation-error.ts
+++ b/packages/datasource-cosmos/src/utils/query-validation-error.ts
@@ -1,3 +1,5 @@
+import { ValidationError } from '@forestadmin/datasource-toolkit';
+
 /**
  * Error codes for query validation failures
  */
@@ -12,15 +14,15 @@ export enum QueryValidationErrorCode {
 }
 
 /**
- * Security and validation errors for query operations
+ * Security and validation errors for query operations.
+ * Extends ValidationError so the agent returns 400 (Bad Request) instead of 500.
  */
-export default class QueryValidationError extends Error {
+export default class QueryValidationError extends ValidationError {
   constructor(
     message: string,
     public readonly code: QueryValidationErrorCode,
     public readonly field?: string,
   ) {
-    super(message);
-    this.name = 'QueryValidationError';
+    super(message, undefined, 'QueryValidationError');
   }
 }

--- a/packages/datasource-cosmos/src/utils/query-validator.ts
+++ b/packages/datasource-cosmos/src/utils/query-validator.ts
@@ -36,7 +36,7 @@ export interface QueryValidatorOptions {
 
   /**
    * Maximum number of conditions in a condition tree
-   * Default: 100
+   * Default: 1000
    */
   maxConditions?: number;
 }
@@ -78,7 +78,7 @@ export default class QueryValidator {
       validateAgainstSchema: options.validateAgainstSchema ?? schemaFields !== undefined,
       allowUnknownFields: options.allowUnknownFields ?? false,
       maxFieldNameLength: options.maxFieldNameLength ?? 256,
-      maxConditions: options.maxConditions ?? 100,
+      maxConditions: options.maxConditions ?? 1000,
     };
 
     if (schemaFields) {

--- a/packages/datasource-cosmos/test/max-conditions.test.ts
+++ b/packages/datasource-cosmos/test/max-conditions.test.ts
@@ -1,0 +1,308 @@
+import { ConditionTreeBranch, ConditionTreeLeaf } from '@forestadmin/datasource-toolkit';
+import { CosmosClient } from '@azure/cosmos';
+
+import QueryValidator, { QueryValidationError } from '../src/utils/query-validator';
+import QueryConverter from '../src/utils/query-converter';
+import CosmosDataSource from '../src/datasource';
+import CosmosCollection from '../src/collection';
+
+/**
+ * Helper: build a flat AND condition tree with N leaf conditions
+ */
+function buildConditionTree(count: number) {
+  const conditions = Array.from(
+    { length: count },
+    (_, i) => new ConditionTreeLeaf(`field${i}`, 'Equal', `value${i}`),
+  );
+
+  return new ConditionTreeBranch('And', conditions);
+}
+
+describe('maxConditions', () => {
+  // ───────────────────────────────────────────────────────────
+  // QueryValidator
+  // ───────────────────────────────────────────────────────────
+  describe('QueryValidator', () => {
+    it('should default maxConditions to 1000', () => {
+      const validator = new QueryValidator();
+
+      // 999 leaf conditions + their parent branch = 1000 nodes → should pass
+      const tree = buildConditionTree(999);
+      expect(() => validator.validateConditionTree(tree)).not.toThrow();
+    });
+
+    it('should reject condition trees exceeding the default 1000 limit', () => {
+      const validator = new QueryValidator();
+
+      // 1001 leaf conditions + their parent branch = 1002 nodes → should fail
+      const tree = buildConditionTree(1001);
+      expect(() => validator.validateConditionTree(tree)).toThrow(QueryValidationError);
+      expect(() => validator.validateConditionTree(tree)).toThrow(/maximum of 1000/);
+    });
+
+    it('should accept exactly 1000 conditions at default', () => {
+      const validator = new QueryValidator();
+
+      // Build a tree that totals exactly 1000 nodes:
+      // 1 branch + 999 leaves = 1000
+      const tree = buildConditionTree(999);
+      expect(() => validator.validateConditionTree(tree)).not.toThrow();
+    });
+
+    it('should reject at 1001 conditions at default', () => {
+      const validator = new QueryValidator();
+
+      // 1 branch + 1000 leaves = 1001 → exceeds 1000
+      const tree = buildConditionTree(1000);
+      expect(() => validator.validateConditionTree(tree)).toThrow(QueryValidationError);
+    });
+
+    it('should respect a custom maxConditions override', () => {
+      const validator = new QueryValidator(undefined, { maxConditions: 2000 });
+
+      // 1 branch + 1500 leaves = 1501 → under 2000
+      const tree = buildConditionTree(1500);
+      expect(() => validator.validateConditionTree(tree)).not.toThrow();
+    });
+
+    it('should reject when custom maxConditions is exceeded', () => {
+      const validator = new QueryValidator(undefined, { maxConditions: 50 });
+
+      const tree = buildConditionTree(60);
+      expect(() => validator.validateConditionTree(tree)).toThrow(/maximum of 50/);
+    });
+
+    it('should include the correct error code when maxConditions is exceeded', () => {
+      const validator = new QueryValidator(undefined, { maxConditions: 5 });
+
+      let thrownError: QueryValidationError | null = null;
+
+      try {
+        validator.validateConditionTree(buildConditionTree(10));
+      } catch (error) {
+        thrownError = error as QueryValidationError;
+      }
+
+      expect(thrownError).toBeInstanceOf(QueryValidationError);
+      expect(thrownError?.message).toContain('maximum of 5');
+    });
+
+    it('should reset condition count between validations', () => {
+      const validator = new QueryValidator(undefined, { maxConditions: 20 });
+
+      // First validation: 15 leaves + 1 branch = 16 → passes
+      expect(() => validator.validateConditionTree(buildConditionTree(15))).not.toThrow();
+
+      // Second validation should also pass (not accumulate from first)
+      expect(() => validator.validateConditionTree(buildConditionTree(15))).not.toThrow();
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────
+  // QueryConverter — maxConditions passthrough
+  // ───────────────────────────────────────────────────────────
+  describe('QueryConverter', () => {
+    it('should use default maxConditions (1000) when no options provided', () => {
+      const converter = new QueryConverter();
+
+      // 999 leaves + 1 branch = 1000 → should pass
+      const tree = buildConditionTree(999);
+      expect(() => converter.getSqlQuerySpec(tree)).not.toThrow();
+    });
+
+    it('should reject when default maxConditions (1000) is exceeded', () => {
+      const converter = new QueryConverter();
+
+      // 1000 leaves + 1 branch = 1001 → should fail
+      const tree = buildConditionTree(1000);
+      expect(() => converter.getSqlQuerySpec(tree)).toThrow(/maximum of 1000/);
+    });
+
+    it('should pass custom maxConditions through to validator', () => {
+      const converter = new QueryConverter({
+        validationOptions: { maxConditions: 2000 },
+      });
+
+      // 1500 leaves + 1 branch = 1501 → under 2000
+      const tree = buildConditionTree(1500);
+      expect(() => converter.getSqlQuerySpec(tree)).not.toThrow();
+    });
+
+    it('should reject when custom maxConditions is exceeded via validationOptions', () => {
+      const converter = new QueryConverter({
+        validationOptions: { maxConditions: 50 },
+      });
+
+      const tree = buildConditionTree(60);
+      expect(() => converter.getSqlQuerySpec(tree)).toThrow(/maximum of 50/);
+    });
+
+    it('should not validate conditions when skipValidation is true', () => {
+      const converter = new QueryConverter({ skipValidation: true });
+
+      // Even 2000 conditions should work when validation is skipped
+      const tree = buildConditionTree(2000);
+      expect(() => converter.getSqlQuerySpec(tree)).not.toThrow();
+    });
+
+    it('should also apply maxConditions in getWhereClause', () => {
+      const converter = new QueryConverter({
+        validationOptions: { maxConditions: 10 },
+      });
+
+      const tree = buildConditionTree(20);
+      expect(() => converter.getWhereClause(tree)).toThrow(/maximum of 10/);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────
+  // CosmosCollection — maxConditions passthrough via constructor
+  // ───────────────────────────────────────────────────────────
+  describe('CosmosCollection', () => {
+    let mockDatasource: any;
+    let mockLogger: jest.Mock;
+    let mockClient: jest.Mocked<CosmosClient>;
+    let mockModel: any;
+
+    beforeEach(() => {
+      mockDatasource = {
+        getCollection: jest.fn(),
+      };
+      mockLogger = jest.fn();
+      mockClient = {} as jest.Mocked<CosmosClient>;
+      mockModel = {
+        name: 'TestCollection',
+        containerName: 'TestContainer',
+        databaseName: 'TestDB',
+        enableCount: true,
+        partitionKeyPath: '/id',
+        getPartitionKeyPath: jest.fn().mockReturnValue('/id'),
+        getAttributes: jest.fn().mockReturnValue({
+          id: { type: 'String' },
+          status: { type: 'String' },
+          operationDate: { type: 'Date' },
+        }),
+        overrideTypeConverter: undefined,
+      };
+    });
+
+    it('should create collection without maxConditions option (uses default 1000)', () => {
+      expect(
+        () => new CosmosCollection(mockDatasource, mockModel, mockLogger, mockClient),
+      ).not.toThrow();
+    });
+
+    it('should create collection with custom maxConditions option', () => {
+      expect(
+        () =>
+          new CosmosCollection(mockDatasource, mockModel, mockLogger, mockClient, {
+            maxConditions: 5000,
+          }),
+      ).not.toThrow();
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────
+  // CosmosDataSource — maxConditions passthrough via options
+  // ───────────────────────────────────────────────────────────
+  describe('CosmosDataSource', () => {
+    let mockClient: jest.Mocked<CosmosClient>;
+    let mockLogger: jest.Mock;
+
+    beforeEach(() => {
+      mockClient = {
+        database: jest.fn().mockReturnValue({
+          container: jest.fn().mockReturnValue({
+            items: {
+              query: jest.fn().mockReturnValue({
+                fetchAll: jest.fn().mockResolvedValue({ resources: [] }),
+              }),
+            },
+          }),
+        }),
+      } as unknown as jest.Mocked<CosmosClient>;
+
+      mockLogger = jest.fn();
+    });
+
+    it('should accept maxConditions in options', () => {
+      expect(
+        () =>
+          new CosmosDataSource(mockClient, [], mockLogger, {
+            maxConditions: 2000,
+          }),
+      ).not.toThrow();
+    });
+
+    it('should work without maxConditions in options', () => {
+      expect(
+        () =>
+          new CosmosDataSource(mockClient, [], mockLogger, {
+            liveQueryConnections: 'cosmos',
+            liveQueryDatabase: 'mydb',
+          }),
+      ).not.toThrow();
+    });
+
+    it('should work with no options at all', () => {
+      expect(() => new CosmosDataSource(mockClient, [], mockLogger)).not.toThrow();
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────
+  // Realistic chart scenario: daily time buckets over a year
+  // ───────────────────────────────────────────────────────────
+  describe('realistic chart scenarios', () => {
+    it('should handle a daily chart over 1 year (365 conditions)', () => {
+      const converter = new QueryConverter();
+
+      // Simulate what Forest Admin generates for a daily chart:
+      // one condition per day bucket over a year
+      const conditions = Array.from({ length: 365 }, (_, i) => {
+        const date = new Date(2025, 0, 1 + i).toISOString();
+
+        return new ConditionTreeLeaf('operationDate', 'Equal', date);
+      });
+      const tree = new ConditionTreeBranch('Or', conditions);
+
+      expect(() => converter.getSqlQuerySpec(tree)).not.toThrow();
+    });
+
+    it('should handle multiple filters combined with daily buckets (3 filters x 365 days)', () => {
+      const converter = new QueryConverter();
+
+      // 3 filters AND'd together, each with 365 OR'd date conditions
+      // Total nodes: 1 (top AND) + 3 (OR branches) + 3*365 (leaves) = 1099
+      // This exceeds the default 1000, which is the scenario the client hit.
+      // With maxConditions=1000, this would fail, so use a higher limit.
+      const customConverter = new QueryConverter({
+        validationOptions: { maxConditions: 1500 },
+      });
+
+      const dateBuckets = Array.from(
+        { length: 365 },
+        (_, i) => new ConditionTreeLeaf('operationDate', 'Equal', new Date(2025, 0, 1 + i).toISOString()),
+      );
+
+      const tree = new ConditionTreeBranch('And', [
+        new ConditionTreeBranch('Or', dateBuckets),
+        new ConditionTreeLeaf('operationType', 'Equal', 'PAYIN'),
+        new ConditionTreeLeaf('operationStatus', 'Equal', 'Completed'),
+      ]);
+
+      expect(() => customConverter.getSqlQuerySpec(tree)).not.toThrow();
+    });
+
+    it('should handle a weekly chart over 2 years (104 conditions)', () => {
+      const converter = new QueryConverter();
+
+      const conditions = Array.from(
+        { length: 104 },
+        (_, i) => new ConditionTreeLeaf('operationDate', 'Equal', `week-${i}`),
+      );
+      const tree = new ConditionTreeBranch('Or', conditions);
+
+      expect(() => converter.getSqlQuerySpec(tree)).not.toThrow();
+    });
+  });
+});

--- a/packages/datasource-cosmos/test/max-conditions.test.ts
+++ b/packages/datasource-cosmos/test/max-conditions.test.ts
@@ -1,4 +1,9 @@
-import { ConditionTreeBranch, ConditionTreeLeaf } from '@forestadmin/datasource-toolkit';
+import {
+  ConditionTreeBranch,
+  ConditionTreeLeaf,
+  ValidationError,
+  BusinessError,
+} from '@forestadmin/datasource-toolkit';
 import { CosmosClient } from '@azure/cosmos';
 
 import QueryValidator, { QueryValidationError } from '../src/utils/query-validator';
@@ -85,6 +90,26 @@ describe('maxConditions', () => {
 
       expect(thrownError).toBeInstanceOf(QueryValidationError);
       expect(thrownError?.message).toContain('maximum of 5');
+    });
+
+    it('should throw a ValidationError (maps to 400 Bad Request in the agent)', () => {
+      const validator = new QueryValidator(undefined, { maxConditions: 5 });
+
+      let thrownError: Error | null = null;
+
+      try {
+        validator.validateConditionTree(buildConditionTree(10));
+      } catch (error) {
+        thrownError = error as Error;
+      }
+
+      // QueryValidationError extends ValidationError from datasource-toolkit
+      expect(thrownError).toBeInstanceOf(ValidationError);
+      expect(thrownError).toBeInstanceOf(BusinessError);
+      // The agent uses BusinessError.isOfType as a fallback for cross-package version mismatches
+      expect(BusinessError.isOfType(thrownError!, ValidationError)).toBe(true);
+      // Preserves the custom name for debugging
+      expect(thrownError?.name).toBe('QueryValidationError');
     });
 
     it('should reset condition count between validations', () => {

--- a/packages/datasource-cosmos/test/max-conditions.test.ts
+++ b/packages/datasource-cosmos/test/max-conditions.test.ts
@@ -1,15 +1,15 @@
+import { CosmosClient } from '@azure/cosmos';
 import {
+  BusinessError,
   ConditionTreeBranch,
   ConditionTreeLeaf,
   ValidationError,
-  BusinessError,
 } from '@forestadmin/datasource-toolkit';
-import { CosmosClient } from '@azure/cosmos';
 
-import QueryValidator, { QueryValidationError } from '../src/utils/query-validator';
-import QueryConverter from '../src/utils/query-converter';
-import CosmosDataSource from '../src/datasource';
 import CosmosCollection from '../src/collection';
+import CosmosDataSource from '../src/datasource';
+import QueryConverter from '../src/utils/query-converter';
+import QueryValidator, { QueryValidationError } from '../src/utils/query-validator';
 
 /**
  * Helper: build a flat AND condition tree with N leaf conditions
@@ -107,6 +107,7 @@ describe('maxConditions', () => {
       expect(thrownError).toBeInstanceOf(ValidationError);
       expect(thrownError).toBeInstanceOf(BusinessError);
       // The agent uses BusinessError.isOfType as a fallback for cross-package version mismatches
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(BusinessError.isOfType(thrownError!, ValidationError)).toBe(true);
       // Preserves the custom name for debugging
       expect(thrownError?.name).toBe('QueryValidationError');
@@ -184,9 +185,11 @@ describe('maxConditions', () => {
   // CosmosCollection — maxConditions passthrough via constructor
   // ───────────────────────────────────────────────────────────
   describe('CosmosCollection', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let mockDatasource: any;
     let mockLogger: jest.Mock;
     let mockClient: jest.Mocked<CosmosClient>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let mockModel: any;
 
     beforeEach(() => {
@@ -294,19 +297,16 @@ describe('maxConditions', () => {
     });
 
     it('should handle multiple filters combined with daily buckets (3 filters x 365 days)', () => {
-      const converter = new QueryConverter();
-
-      // 3 filters AND'd together, each with 365 OR'd date conditions
       // Total nodes: 1 (top AND) + 3 (OR branches) + 3*365 (leaves) = 1099
-      // This exceeds the default 1000, which is the scenario the client hit.
-      // With maxConditions=1000, this would fail, so use a higher limit.
+      // This exceeds the default 1000, so use a higher limit.
       const customConverter = new QueryConverter({
         validationOptions: { maxConditions: 1500 },
       });
 
       const dateBuckets = Array.from(
         { length: 365 },
-        (_, i) => new ConditionTreeLeaf('operationDate', 'Equal', new Date(2025, 0, 1 + i).toISOString()),
+        (_, i) =>
+          new ConditionTreeLeaf('operationDate', 'Equal', new Date(2025, 0, 1 + i).toISOString()),
       );
 
       const tree = new ConditionTreeBranch('And', [


### PR DESCRIPTION
## Summary
- Raises the default `maxConditions` from 100 to 1000 in `QueryValidator`, fixing chart queries that fail with `QueryValidationError: Condition tree exceeds maximum of 100 conditions` when using daily time buckets over long date ranges
- Exposes `maxConditions` as a configurable option in `createCosmosDataSource` for users who need higher limits
- Threads the option through `CosmosDataSource` → `CosmosCollection` → `QueryConverter` → `QueryValidator`
- **Fixes HTTP status code**: `QueryValidationError` now extends `ValidationError` from datasource-toolkit, so the agent returns **400 Bad Request** instead of **500 Internal Server Error** when the condition limit is hit

## Context
Forest Admin charts with daily granularity generate one condition per time bucket. A year of daily data = 365 conditions, and adding 2-3 filters pushes it over 1000. The previous default of 100 broke charts for any date range beyond ~3 months.

Additionally, `QueryValidationError` extended plain `Error`, causing the agent's error handler to fall through to the default 500 status code. A query validation issue is a client error (400), not a server error (500).

## Test plan
- [x] 23 new tests in `max-conditions.test.ts` covering:
  - Default of 1000 at `QueryValidator` level (boundary tests at 1000/1001)
  - Custom `maxConditions` passthrough via `QueryConverter`, `CosmosCollection`, and `CosmosDataSource`
  - Realistic chart scenarios (daily chart over 1 year, 3 filters × 365 days, weekly over 2 years)
  - `QueryValidationError` is `instanceof ValidationError` and passes `BusinessError.isOfType` check
- [x] All 128 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Increase `maxConditions` default from 100 to 1000 in Cosmos datasource query validator
> - Raises the default `maxConditions` limit in [`QueryValidator`](https://github.com/ForestAdmin/forestadmin-experimental/pull/212/files#diff-8ac4b58bb2448a429e94af15c05dd9ddc37617c39ea97f9cfdddfd712c84b87f) from 100 to 1000, fixing failures for queries with large condition trees (e.g. chart filters).
> - Adds a `maxConditions` option to `createCosmosDataSource`, `CosmosDataSource`, and `CosmosCollection` so callers can override the limit.
> - Changes `QueryValidationError` to extend `ValidationError` from `@forestadmin/datasource-toolkit`, so validation failures return HTTP 400 instead of 500.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4cf51be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->