### PR TITLE
ci: fix release flow in case of more than one package modified

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,18 @@ jobs:
           && (
             github.ref == 'refs/heads/main'
           )
-        run: npx nx affected --base=origin/main~1 --head=origin/main -t publish:package
+        run: |
+          set -e
+          PROJECTS=$(npx nx print-affected --base=origin/main~1 --head=origin/main --target=publish:package --select=projects)
+          PROJECTS=$(echo "$PROJECTS" | tr -d ' ' | tr ',' '\n')
+          if [ -z "$PROJECTS" ]; then
+            echo "No affected packages to publish"
+            exit 0
+          fi
+          for PROJECT in $PROJECTS; do
+            echo "=== Releasing $PROJECT ==="
+            npx nx run "$PROJECT:publish:package"
+          done
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix CI release flow to publish each affected package individually on main
Replaces the single `npx nx print-affected` publish command in [build.yml](.github/workflows/build.yml) with a bash script that iterates over each affected project and runs `npx nx run "$PROJECT:publish:package"` for each one. The script exits early with a message when no packages are affected, and uses `set -e` to stop on the first failure.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 046fa5b.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->