### PR TITLE
fix(rpc agent): use schema path option

### DIFF
--- a/packages/rpc-agent/src/agent.ts
+++ b/packages/rpc-agent/src/agent.ts
@@ -64,7 +64,7 @@ export default class RpcAgent<S extends TSchema = TSchema> extends Agent<S> {
     this.options.logger('Debug', `RPC agent schema hash computed: ${this._buildedSchema.etag}`);
 
     await fs.writeFile(
-      '.forestadmin-rpc-schema.json',
+      this.options.schemaPath || '.forestadmin-rpc-schema.json',
       JSON.stringify(this._buildedSchema, null, 2),
     );
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix `RpcAgent.sendSchema` to use `options.schemaPath` when writing the schema file
The schema write path in `RpcAgent.sendSchema` was ignoring the `schemaPath` option. It now uses `this.options.schemaPath` when defined, falling back to `.forestadmin-rpc-schema.json`. See [agent.ts](https://github.com/ForestAdmin/forestadmin-experimental/pull/214/files#diff-0e8d5c13e339e8ad9b93fffe734576fd36480a98aa1a3c9901192eb92f832eef).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee02f56.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->