### PR TITLE
fix(rpc agent): use schema path option

### DIFF
--- a/packages/datasource-rpc/package.json
+++ b/packages/datasource-rpc/package.json
@@ -15,12 +15,13 @@
     "superagent": "^8.0.6"
   },
   "devDependencies": {
-    "@forestadmin/datasource-customizer": "^1.69.0",
-    "@forestadmin/datasource-toolkit": "^1.53.0"
+    "@forestadmin/datasource-customizer": "^1.69.3",
+    "@forestadmin/datasource-toolkit": "^1.53.1",
+    "@types/superagent": "^8.1.6"
   },
   "peerDependencies": {
-    "@forestadmin/datasource-customizer": "^1.69.0",
-    "@forestadmin/datasource-toolkit": "^1.53.0"
+    "@forestadmin/datasource-customizer": "^1.69.3",
+    "@forestadmin/datasource-toolkit": "^1.53.1"
   },
   "files": [
     "dist/**/*.js",

--- a/packages/datasource-rpc/src/collection.ts
+++ b/packages/datasource-rpc/src/collection.ts
@@ -123,11 +123,12 @@ export default class RpcCollection extends BaseCollection {
     appendHeaders(request, this.options.authSecret, caller);
     const response = await request.send({ action: name, filter, data: formValues });
 
-    response.body.invalidated = new Set(response.body.invalidated);
+    const body = keysToCamel(response.body);
+    body.invalidated = new Set(body.invalidated);
 
     // TODO action with file
 
-    return keysToCamel(response.body);
+    return body;
   }
 
   override async getForm(

--- a/packages/datasource-rpc/src/index.ts
+++ b/packages/datasource-rpc/src/index.ts
@@ -1,132 +1,16 @@
 import { DataSourceFactory, Logger } from '@forestadmin/datasource-toolkit';
-import superagent from 'superagent';
 
 import RpcDataSource from './datasource';
-import { IntrospectionSchema, RpcDataSourceOptions, RpcSchema } from './types';
-import { appendHeaders, cameliseKeys, toPascalCase } from './utils';
+import { getIntrospection, parseIntrospection } from './introspector';
+import Poller from './poller';
+import { RpcDataSourceOptions, RpcSchema } from './types';
 
 export { reconciliateRpc } from './plugins';
-
-/** polling interval in second */
-const DEFAULT_POLLING_INTERVAL = 600;
-const MIN_POLLING_INTERVAL = 1;
-const MAX_POLLING_INTERVAL = 3600;
-
-function parseIntrospection(introSchema: IntrospectionSchema): RpcSchema {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  const { collections, charts, rpc_relations, native_query_connections, etag } = introSchema;
-
-  const parsedCollections = collections.map(collection => {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    const { actions, fields, aggregation_capabilities, ...rest } = collection;
-    const parsedActions = Object.entries(actions).reduce((pActions, [name, schema]) => {
-      pActions[name] = cameliseKeys(schema);
-
-      return pActions;
-    }, {});
-
-    const parsedFields = Object.entries(fields).reduce((pFields, [name, schema]) => {
-      pFields[name] = cameliseKeys(schema);
-
-      if (schema.type === 'Column') {
-        pFields[name].filterOperators = new Set(pFields[name].filterOperators.map(toPascalCase));
-      }
-
-      return pFields;
-    }, {});
-
-    return {
-      ...rest,
-      aggregationCapabilities: {
-        supportedDateOperations: new Set(aggregation_capabilities.supported_date_operations),
-        supportGroups: aggregation_capabilities.support_groups,
-      },
-      actions: parsedActions,
-      fields: parsedFields,
-    };
-  });
-
-  const parsedRelations = Object.entries(rpc_relations).reduce(
-    (rpcRelations, [collectionName, collectionRelations]) => {
-      rpcRelations[collectionName] = Object.entries(collectionRelations).reduce(
-        (relations, [name, schema]) => {
-          relations[name] = cameliseKeys(schema);
-
-          return relations;
-        },
-        {},
-      );
-
-      return rpcRelations;
-    },
-    {},
-  );
-
-  return {
-    collections: parsedCollections,
-    charts,
-    rpcRelations: parsedRelations,
-    nativeQueryConnections: native_query_connections,
-    etag,
-  };
-}
-
-async function getIntrospection(
-  logger: Logger,
-  uri: string,
-  authSecret: string,
-  etag?: string,
-): Promise<RpcSchema> {
-  logger('Info', `Getting schema from Rpc agent on ${uri}.`);
-
-  const introRq = superagent.get(`${uri}/forest/rpc-schema`);
-  appendHeaders(introRq, authSecret);
-  if (etag) introRq.set('if-none-match', etag);
-
-  const introResp = await introRq.send();
-
-  return parseIntrospection(introResp.body);
-}
-
-function startPolling(
-  logger: Logger,
-  options: { uri: string; authSecret: string; etag: string; pollingInterval?: number },
-  onChange: () => Promise<void>,
-) {
-  const { uri, authSecret, etag, pollingInterval } = options;
-  logger(
-    'Debug',
-    `Starting polling every ${pollingInterval} seconds for Rpc agent schema changes on ${uri}.`,
-  );
-
-  const inter = setInterval(async () => {
-    try {
-      const intro = await getIntrospection(logger, uri, authSecret, etag);
-
-      if (etag !== intro?.etag) {
-        logger('Info', `Schema change detected on Rpc agent ${uri}. Restarting agent.`);
-        clearInterval(inter);
-        onChange();
-      }
-    } catch (error) {
-      if (error.status === 304) {
-        logger('Debug', `No schema change detected on Rpc agent ${uri}.`);
-      } else if (!error.status) {
-        logger('Error', `Error while polling Rpc agent ${uri} for schema changes: Unreachable.`);
-      } else {
-        logger(
-          'Error',
-          `Error while polling Rpc agent ${uri} for schema changes: ${error.message}.`,
-        );
-      }
-    }
-  }, pollingInterval * 1000);
-}
 
 export function createRpcDataSource(options: RpcDataSourceOptions): DataSourceFactory {
   return async (logger: Logger, restartAgent: () => Promise<void>) => {
     const { authSecret, uri } = options;
-    const { introspection } = options;
+    const { introspection, pollingInterval } = options;
     let schema: RpcSchema;
 
     try {
@@ -137,11 +21,12 @@ export function createRpcDataSource(options: RpcDataSourceOptions): DataSourceFa
       schema = parseIntrospection(introspection);
     }
 
-    const pollingInterval = Math.min(
-      Math.max(options.pollingInterval ?? DEFAULT_POLLING_INTERVAL, MIN_POLLING_INTERVAL),
-      MAX_POLLING_INTERVAL,
+    Poller.getInstance(logger, restartAgent).startPolling(
+      uri,
+      authSecret,
+      schema.etag,
+      pollingInterval,
     );
-    startPolling(logger, { uri, authSecret, etag: schema.etag, pollingInterval }, restartAgent);
 
     return new RpcDataSource(logger, options, schema);
   };

--- a/packages/datasource-rpc/src/introspector.ts
+++ b/packages/datasource-rpc/src/introspector.ts
@@ -1,0 +1,81 @@
+import { Logger } from '@forestadmin/datasource-toolkit';
+import superagent from 'superagent';
+
+import { IntrospectionSchema, RpcSchema } from './types';
+import { appendHeaders, cameliseKeys, toPascalCase } from './utils';
+
+export function parseIntrospection(introSchema: IntrospectionSchema): RpcSchema {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const { collections, charts, rpc_relations, native_query_connections, etag } = introSchema;
+
+  const parsedCollections = collections.map(collection => {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const { actions, fields, aggregation_capabilities, ...rest } = collection;
+    const parsedActions = Object.entries(actions).reduce((pActions: any, [name, schema]) => {
+      pActions[name] = cameliseKeys(schema);
+
+      return pActions;
+    }, {});
+
+    const parsedFields = Object.entries(fields).reduce((pFields: any, [name, schema]) => {
+      pFields[name] = cameliseKeys(schema);
+
+      if (schema.type === 'Column') {
+        pFields[name].filterOperators = new Set(pFields[name].filterOperators.map(toPascalCase));
+      }
+
+      return pFields;
+    }, {});
+
+    return {
+      ...rest,
+      aggregationCapabilities: {
+        supportedDateOperations: new Set(aggregation_capabilities.supported_date_operations),
+        supportGroups: aggregation_capabilities.support_groups,
+      },
+      actions: parsedActions,
+      fields: parsedFields,
+    };
+  });
+
+  const parsedRelations = Object.entries(rpc_relations).reduce(
+    (rpcRelations: any, [collectionName, collectionRelations]) => {
+      rpcRelations[collectionName] = Object.entries(collectionRelations).reduce(
+        (relations: any, [name, schema]) => {
+          relations[name] = cameliseKeys(schema);
+
+          return relations;
+        },
+        {},
+      );
+
+      return rpcRelations;
+    },
+    {},
+  );
+
+  return {
+    collections: parsedCollections,
+    charts,
+    rpcRelations: parsedRelations,
+    nativeQueryConnections: native_query_connections,
+    etag,
+  };
+}
+
+export async function getIntrospection(
+  logger: Logger,
+  uri: string,
+  authSecret: string,
+  etag?: string,
+): Promise<RpcSchema> {
+  logger('Info', `Getting schema from Rpc agent on ${uri}.`);
+
+  const introRq = superagent.get(`${uri}/forest/rpc-schema`);
+  appendHeaders(introRq, authSecret);
+  if (etag) introRq.set('if-none-match', etag);
+
+  const introResp = await introRq.send();
+
+  return parseIntrospection(introResp.body);
+}

--- a/packages/datasource-rpc/src/poller.ts
+++ b/packages/datasource-rpc/src/poller.ts
@@ -1,0 +1,74 @@
+import { Logger } from '@forestadmin/datasource-toolkit';
+
+import { getIntrospection } from './introspector';
+
+let POLLER: Poller;
+
+/** polling interval in second */
+const DEFAULT_POLLING_INTERVAL = 600;
+const MIN_POLLING_INTERVAL = 1;
+const MAX_POLLING_INTERVAL = 3600;
+
+export default class Poller {
+  private readonly logger: Logger;
+  private readonly onChange: () => Promise<void>;
+
+  private readonly pollingMap: Map<string, string>;
+
+  static getInstance(logger: Logger, onChange: Poller['onChange']) {
+    if (!POLLER) POLLER = new Poller(logger, onChange);
+
+    return POLLER;
+  }
+
+  constructor(logger: Logger, onChange: Poller['onChange']) {
+    this.logger = logger;
+    this.onChange = onChange;
+
+    this.pollingMap = new Map();
+  }
+
+  startPolling(uri: string, authSecret: string, startingEtag: string, pollingInterval?: number) {
+    if (this.pollingMap.has(uri)) return;
+
+    const interval = Math.min(
+      Math.max(pollingInterval ?? DEFAULT_POLLING_INTERVAL, MIN_POLLING_INTERVAL),
+      MAX_POLLING_INTERVAL,
+    );
+
+    this.logger(
+      'Debug',
+      `Starting polling every ${interval} seconds for Rpc agent schema changes on ${uri}.`,
+    );
+
+    this.pollingMap.set(uri, startingEtag);
+
+    setInterval(async () => {
+      try {
+        const etag = this.pollingMap.get(uri);
+        const intro = await getIntrospection(this.logger, uri, authSecret, etag);
+
+        if (etag !== intro?.etag) {
+          this.logger('Info', `Schema change detected on Rpc agent ${uri}. Restarting agent.`);
+
+          await this.onChange();
+          this.pollingMap.set(uri, intro.etag);
+        }
+      } catch (error: any) {
+        if (error.status === 304) {
+          this.logger('Debug', `No schema change detected on Rpc agent ${uri}.`);
+        } else if (!error.status) {
+          this.logger(
+            'Error',
+            `Error while polling Rpc agent ${uri} for schema changes: Unreachable.`,
+          );
+        } else {
+          this.logger(
+            'Error',
+            `Error while polling Rpc agent ${uri} for schema changes: ${error.message}.`,
+          );
+        }
+      }
+    }, interval * 1000);
+  }
+}

--- a/packages/rpc-agent/package.json
+++ b/packages/rpc-agent/package.json
@@ -13,9 +13,9 @@
   },
   "dependencies": {
     "@koa/router": "^12.0.0",
-    "@forestadmin/agent": "^1.75.0",
-    "@forestadmin/datasource-customizer": "^1.69.0",
-    "@forestadmin/datasource-toolkit": "^1.53.0"
+    "@forestadmin/agent": "^1.78.9",
+    "@forestadmin/datasource-customizer": "^1.69.3",
+    "@forestadmin/datasource-toolkit": "^1.53.1"
   },
   "files": [
     "dist/**/*.js",

--- a/packages/rpc-agent/package.json
+++ b/packages/rpc-agent/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@koa/router": "^12.0.0",
-    "@forestadmin/agent": "^1.78.9",
+    "@forestadmin/agent": "^1.78.10",
     "@forestadmin/datasource-customizer": "^1.69.3",
     "@forestadmin/datasource-toolkit": "^1.53.1"
   },

--- a/packages/rpc-agent/src/agent.ts
+++ b/packages/rpc-agent/src/agent.ts
@@ -64,7 +64,7 @@ export default class RpcAgent<S extends TSchema = TSchema> extends Agent<S> {
     this.options.logger('Debug', `RPC agent schema hash computed: ${this._buildedSchema.etag}`);
 
     await fs.writeFile(
-      '.forestadmin-rpc-schema.json',
+      this.options.schemaPath || '.forestadmin-rpc-schema.json',
       JSON.stringify(this._buildedSchema, null, 2),
     );
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix `RpcAgent.sendSchema` to write schema file to the configured `schemaPath`
- `RpcAgent.sendSchema` now uses `this.options.schemaPath` when set, falling back to `.forestadmin-rpc-schema.json`.
- Polling logic is extracted into a `Poller` singleton in [poller.ts](https://github.com/ForestAdmin/forestadmin-experimental/pull/215/files#diff-924f2275c4b224c5f4a899d93f5f86c9919bf7c5d9c283177542f3748f025462), deduplicating intervals per URI and persisting etag state across `createRpcDataSource` restarts.
- Fixes a bug in `RpcCollection.executeAction` where camelCasing was applied after mutating the raw response, causing the `invalidated` Set to be set on the wrong key.

<!-- Macroscope's changelog starts here -->
#### Changes since #215 opened

- Updated `@forestadmin/agent` dependency version in `rpc-agent` package [a7db867]
<!-- Macroscope's changelog ends here -->

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9be094a.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->