### PR TITLE
fix(ds-elasticsearch): propagate enableCount option to the underlying model

### DIFF
--- a/packages/datasource-elasticsearch/src/introspection/builder.ts
+++ b/packages/datasource-elasticsearch/src/introspection/builder.ts
@@ -61,7 +61,12 @@ export interface ElasticsearchDatasourceOptionsBuilder {
   /**
    * Add a collection from an index
    */
-  addCollectionFromIndex({ name, indexName }: ElasticsearchCollectionFromIndexOptions): this;
+  addCollectionFromIndex({
+    name,
+    indexName,
+    overrideTypeConverter,
+    enableCount,
+  }: ElasticsearchCollectionFromIndexOptions): this;
 
   /**
    * Add a collection from a template
@@ -71,6 +76,7 @@ export interface ElasticsearchDatasourceOptionsBuilder {
     templateName,
     generateIndexName,
     overrideTypeConverter,
+    enableCount,
   }: ElasticsearchCollectionFromTemplateOptions): this;
 }
 
@@ -90,6 +96,7 @@ export class ElasticsearchDatasourceBuilder implements ElasticsearchDatasourceOp
     name,
     indexName,
     overrideTypeConverter,
+    enableCount,
   }: ElasticsearchCollectionFromIndexOptions): this {
     this.collectionsPromises.push(
       (async () => {
@@ -108,6 +115,7 @@ export class ElasticsearchDatasourceBuilder implements ElasticsearchDatasourceOp
           mapping[indexName].mappings,
           () => indexName,
           overrideTypeConverter,
+          enableCount,
         );
       })(),
     );
@@ -120,6 +128,7 @@ export class ElasticsearchDatasourceBuilder implements ElasticsearchDatasourceOp
     templateName,
     generateIndexName,
     overrideTypeConverter,
+    enableCount,
   }: ElasticsearchCollectionFromTemplateOptions): this {
     this.collectionsPromises.push(
       (async () => {
@@ -129,6 +138,7 @@ export class ElasticsearchDatasourceBuilder implements ElasticsearchDatasourceOp
           name,
           typeof generateIndexName === 'string' ? () => generateIndexName : generateIndexName,
           overrideTypeConverter,
+          enableCount,
         );
 
         return modelFromTemplate;

--- a/packages/datasource-elasticsearch/src/introspection/template-introspector.ts
+++ b/packages/datasource-elasticsearch/src/introspection/template-introspector.ts
@@ -12,6 +12,7 @@ export default async function introspectTemplate(
   overrideName?: string,
   generateIndexName?: (record?: unknown) => string,
   overrideTypeConverter?: OverrideTypeConverter,
+  enableCount?: boolean,
 ) {
   const isIndexTemplate = await elasticsearchClient.indices.existsIndexTemplate({
     name: templateName,
@@ -40,6 +41,7 @@ export default async function introspectTemplate(
       mappings,
       generateIndexName,
       overrideTypeConverter,
+      enableCount,
     );
   }
 
@@ -59,5 +61,6 @@ export default async function introspectTemplate(
     mappings,
     generateIndexName,
     overrideTypeConverter,
+    enableCount,
   );
 }

--- a/packages/datasource-elasticsearch/test/collection.test.ts
+++ b/packages/datasource-elasticsearch/test/collection.test.ts
@@ -51,6 +51,42 @@ describe('ElasticsearchDataSource > Collection', () => {
     expect(elasticsearchCollection.nativeDriver).toBeDefined();
   });
 
+  describe('count capability', () => {
+    const buildCollection = (enableCount?: boolean) => {
+      const dataSource = Symbol('datasource') as unknown as DataSource;
+      const mockClient = new MockClient();
+      const client = new Client({
+        node: 'http://localhost:9200',
+        Connection: mockClient.getConnection(),
+      });
+
+      const model = new ModelElasticsearch(
+        client,
+        '__collection__',
+        ['indexPattern'],
+        ['alias'],
+        { properties: { name: { type: 'integer' } } },
+        undefined,
+        undefined,
+        enableCount,
+      );
+
+      return new ElasticsearchCollection(dataSource, model, jest.fn(), client);
+    };
+
+    it('exposes a countable schema when the model has enableCount = true', () => {
+      const collection = buildCollection(true);
+
+      expect(collection.schema.countable).toBe(true);
+    });
+
+    it('exposes a non-countable schema by default', () => {
+      const collection = buildCollection();
+
+      expect(collection.schema.countable).toBe(false);
+    });
+  });
+
   // describe('create', () => {
   // });
 

--- a/packages/datasource-elasticsearch/test/introspection/builder.integration.test.ts
+++ b/packages/datasource-elasticsearch/test/introspection/builder.integration.test.ts
@@ -161,5 +161,34 @@ describe('introspection > builder', () => {
 
       await deleteElasticsearchTemplate('test-template', 'test-template-*');
     });
+
+    it('should propagate enableCount to the produced model', async () => {
+      const { client } = await createElasticsearchTemplate(
+        'test-template-count',
+        {
+          indexPattern: 'test-template-count-*',
+          alias: 'test-template-count-alias',
+          mapping: {
+            dynamic: 'strict',
+            properties: { id: { type: 'integer' } },
+          },
+        },
+        [{ id: 1, index: 'test-template-count-index' }],
+      );
+
+      const elasticsearchDatasourceBuilder = new ElasticsearchDatasourceBuilder(client);
+
+      elasticsearchDatasourceBuilder.addCollectionFromTemplate({
+        name: 'countable',
+        templateName: 'test-template-count',
+        enableCount: true,
+      });
+
+      const [model] = await elasticsearchDatasourceBuilder.createCollectionsFromConfiguration();
+
+      expect(model.enableCount).toBe(true);
+
+      await deleteElasticsearchTemplate('test-template-count', 'test-template-count-*');
+    });
   });
 });


### PR DESCRIPTION
## Summary

The `enableCount` option exposed on `addCollectionFromIndex` and `addCollectionFromTemplate` was documented and typed, but never destructured from the options object — and `introspectTemplate` didn't accept it either. As a result, `enableCount: true` was silently dropped, the produced `ModelElasticsearch` had `enableCount === undefined`, and `ElasticsearchCollection`'s constructor never called `this.enableCount()`.

Symptom in Forest Admin: collections backed by this datasource appear non-countable in the UI — no `1-15 of N` total, and (depending on the frontend version) no next-page control — even when consumers explicitly opt in via `enableCount: true`.

## Changes

- `src/introspection/builder.ts`: destructure `enableCount` in both `addCollectionFromIndex` and `addCollectionFromTemplate`, and forward it to `ModelElasticsearch` / `introspectTemplate`. Added the option to the `ElasticsearchDatasourceOptionsBuilder` interface signatures for consistency.
- `src/introspection/template-introspector.ts`: accept `enableCount` and pass it to both `ModelElasticsearch` constructor branches (legacy + index template).
- `test/collection.test.ts`: unit-test the wiring — the produced `ElasticsearchCollection`'s schema is `countable: true` iff the model has `enableCount = true`, otherwise `countable: false`.
- `test/introspection/builder.integration.test.ts`: integration-test the propagation through `addCollectionFromTemplate`.

No public API changes — `enableCount` was already declared on `ElasticsearchCollectionBase`.

## Test plan

- [x] `yarn build` passes
- [x] `yarn lint` passes
- [x] `npx jest --testPathIgnorePatterns=integration` — 102/102 passing (includes 2 new unit tests in `collection.test.ts`)
- [ ] Integration suite (requires `docker compose up`) — locally verified with the new builder integration test; please re-run in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Propagate `enableCount` option to `ModelElasticsearch` in the Elasticsearch datasource builder
> The `enableCount` flag was accepted by `addCollectionFromIndex` and `addCollectionFromTemplate` in the builder interface but not forwarded to the underlying `ModelElasticsearch` constructor, causing count capability to always be disabled.
>
> - [builder.ts](https://github.com/ForestAdmin/forestadmin-experimental/pull/216/files#diff-633fbe634c619a215d01565c473c049f99978da4675520c886391f35536c5bf7) now destructures `enableCount` from options and passes it to `ModelElasticsearch` (via direct construction or `introspectTemplate`).
> - [template-introspector.ts](https://github.com/ForestAdmin/forestadmin-experimental/pull/216/files#diff-ebc572c7784f9818728be98798597805a0642af9f623e475d46449cde877d12c) accepts `enableCount` as an optional parameter and forwards it to `ModelElasticsearch` in both index and legacy template branches.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec4ae19.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->