### PR TITLE
fix(rpc): handle sa schema properly with multi stack

### DIFF
--- a/packages/datasource-rpc/src/introspector.ts
+++ b/packages/datasource-rpc/src/introspector.ts
@@ -12,7 +12,9 @@ export function parseIntrospection(introSchema: IntrospectionSchema): RpcSchema 
     // eslint-disable-next-line @typescript-eslint/naming-convention
     const { actions, fields, aggregation_capabilities, ...rest } = collection;
     const parsedActions = Object.entries(actions).reduce((pActions: any, [name, schema]) => {
-      pActions[name] = cameliseKeys(schema);
+      const camelSchema = cameliseKeys(schema) as Record<string, unknown>;
+      camelSchema.generateFile = camelSchema.isGenerateFile;
+      pActions[name] = camelSchema;
 
       return pActions;
     }, {});

--- a/packages/datasource-rpc/test/introspector.test.ts
+++ b/packages/datasource-rpc/test/introspector.test.ts
@@ -1,0 +1,49 @@
+import { parseIntrospection } from '../src/introspector';
+import { IntrospectionSchema } from '../src/types';
+
+function buildIntroSchema(actionSchema: Record<string, unknown>): IntrospectionSchema {
+  return {
+    etag: 'etag',
+    charts: [],
+    native_query_connections: [],
+    rpc_relations: {},
+    collections: [
+      {
+        name: 'Files',
+        countable: false,
+        searchable: false,
+        charts: [],
+        segments: [],
+        fields: {},
+        actions: { download: actionSchema },
+        aggregation_capabilities: {
+          supported_date_operations: [],
+          support_groups: false,
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+    ],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+describe('parseIntrospection', () => {
+  it('exposes is_generate_file from the wire as generateFile expected by the JS toolkit', () => {
+    const parsed = parseIntrospection(
+      buildIntroSchema({ scope: 'Single', is_generate_file: true, description: 'export' }),
+    );
+
+    const action = parsed.collections[0].actions.download as Record<string, unknown>;
+    expect(action.generateFile).toBe(true);
+    expect(action.scope).toBe('Single');
+    expect(action.description).toBe('export');
+  });
+
+  it('leaves generateFile undefined when is_generate_file is absent', () => {
+    const parsed = parseIntrospection(buildIntroSchema({ scope: 'Single' }));
+
+    const action = parsed.collections[0].actions.download as Record<string, unknown>;
+    expect(action.generateFile).toBeUndefined();
+    expect(action.scope).toBe('Single');
+  });
+});

--- a/packages/rpc-agent/src/agent.ts
+++ b/packages/rpc-agent/src/agent.ts
@@ -97,7 +97,11 @@ export default class RpcAgent<S extends TSchema = TSchema> extends Agent<S> {
     }, {});
 
     const buildedActions = Object.entries(actions).reduce((bActions, [name, schema]) => {
-      bActions[name] = keysToSnake(schema);
+      const snakeSchema = keysToSnake(schema) as Record<string, unknown>;
+      // Ruby toolkit reads the flag as `is_generate_file`; align the wire format with that
+      // convention so Ruby main agents pick it up without an ad-hoc mapping on their side.
+      snakeSchema.is_generate_file = snakeSchema.generate_file;
+      bActions[name] = snakeSchema;
 
       return bActions;
     }, {});

--- a/packages/rpc-agent/test/agent.test.ts
+++ b/packages/rpc-agent/test/agent.test.ts
@@ -1,0 +1,58 @@
+import RpcAgent from '../src/agent';
+
+function createAgent(): RpcAgent {
+  return Object.create(RpcAgent.prototype) as RpcAgent;
+}
+
+function buildCollectionFixture(actionSchema: Record<string, unknown>) {
+  return {
+    name: 'Files',
+    schema: {
+      fields: {},
+      actions: { download: actionSchema },
+      aggregationCapabilities: {
+        supportedDateOperations: new Set<string>(),
+        supportGroups: false,
+      },
+      countable: false,
+      searchable: false,
+      charts: [],
+      segments: [],
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+describe('RpcAgent.buildCollection', () => {
+  it('serialises generateFile as is_generate_file so Ruby main agents read it natively', () => {
+    const agent = createAgent();
+    const collection = buildCollectionFixture({
+      scope: 'Single',
+      generateFile: true,
+      description: 'export',
+    });
+
+    const built = agent.buildCollection(collection, {}) as { actions: Record<string, unknown> };
+    const action = built.actions.download as Record<string, unknown>;
+
+    expect(action).toEqual({
+      scope: 'Single',
+      is_generate_file: true,
+      description: 'export',
+    });
+    expect(action).not.toHaveProperty('generate_file');
+    expect(action).not.toHaveProperty('generateFile');
+  });
+
+  it('does not introduce is_generate_file when the source schema omits generateFile', () => {
+    const agent = createAgent();
+    const collection = buildCollectionFixture({ scope: 'Single' });
+
+    const built = agent.buildCollection(collection, {}) as { actions: Record<string, unknown> };
+    const action = built.actions.download as Record<string, unknown>;
+
+    expect(action).toEqual({ scope: 'Single' });
+    expect(action).not.toHaveProperty('is_generate_file');
+    expect(action).not.toHaveProperty('generate_file');
+  });
+});


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix `generateFile`/`is_generate_file` serialization in RPC action schemas for multi-stack
- [`RpcAgent.buildCollection`](https://github.com/ForestAdmin/forestadmin-experimental/pull/218/files#diff-0e8d5c13e339e8ad9b93fffe734576fd36480a98aa1a3c9901192eb92f832eef) now explicitly sets `is_generate_file` from `generateFile` when serializing action schemas, so the field is correctly transmitted over the wire.
- [`parseIntrospection`](https://github.com/ForestAdmin/forestadmin-experimental/pull/218/files#diff-86431bbfe810395449851f13164ace8139f42ede1a4c043aeb6fba274f692413) now maps `isGenerateFile` (camelised from `is_generate_file`) back to `generateFile` on the parsed action schema.
- Tests added in both packages to assert correct round-trip behavior and that the field is absent when not set.

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 410aa1f. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>

### 🗂️ Filtered Issues

</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->