### PR TITLE
fix(rpc datatource): allow connect ruby as rpc

### DIFF
--- a/packages/datasource-rpc/src/collection.ts
+++ b/packages/datasource-rpc/src/collection.ts
@@ -15,7 +15,7 @@ import {
 import superagent from 'superagent';
 
 import { RpcDataSourceOptions } from './types';
-import { appendHeaders, keysToCamel } from './utils';
+import { appendHeaders, keysToCamel, keysToSnake } from './utils';
 
 export default class RpcCollection extends BaseCollection {
   private readonly logger: Logger;
@@ -74,7 +74,7 @@ export default class RpcCollection extends BaseCollection {
 
     const request = superagent.post(url);
     appendHeaders(request, this.options.authSecret, caller);
-    const response = await request.send({ projection, filter });
+    const response = await request.send({ projection, filter: keysToSnake(filter) });
 
     return response.body;
   }
@@ -86,7 +86,7 @@ export default class RpcCollection extends BaseCollection {
 
     const request = superagent.post(url);
     appendHeaders(request, this.options.authSecret, caller);
-    await request.send({ patch, filter });
+    await request.send({ patch, filter: keysToSnake(filter) });
   }
 
   async delete(caller: Caller, filter: Filter) {
@@ -96,7 +96,7 @@ export default class RpcCollection extends BaseCollection {
 
     const request = superagent.post(url);
     appendHeaders(request, this.options.authSecret, caller);
-    await request.send({ filter });
+    await request.send({ filter: keysToSnake(filter) });
   }
 
   async aggregate(caller: Caller, filter: Filter, aggregation: Aggregation, limit?: number) {
@@ -106,7 +106,11 @@ export default class RpcCollection extends BaseCollection {
 
     const request = superagent.post(url);
     appendHeaders(request, this.options.authSecret, caller);
-    const response = await request.send({ filter, aggregation, limit });
+    const response = await request.send({
+      filter: keysToSnake(filter),
+      aggregation: keysToSnake(aggregation),
+      limit,
+    });
 
     return response.body;
   }
@@ -121,7 +125,11 @@ export default class RpcCollection extends BaseCollection {
 
     const request = superagent.post(url);
     appendHeaders(request, this.options.authSecret, caller);
-    const response = await request.send({ action: name, filter, data: formValues });
+    const response = await request.send({
+      action: name,
+      filter: keysToSnake(filter),
+      data: formValues,
+    });
 
     const body = keysToCamel(response.body);
     body.invalidated = new Set(body.invalidated);
@@ -147,7 +155,12 @@ export default class RpcCollection extends BaseCollection {
 
     const request = superagent.post(url);
     appendHeaders(request, this.options.authSecret, caller);
-    const response = await request.send({ action: name, filter, metas, data: formValues });
+    const response = await request.send({
+      action: name,
+      filter: keysToSnake(filter),
+      metas: keysToSnake(metas),
+      data: formValues,
+    });
 
     return keysToCamel(response.body);
   }

--- a/packages/datasource-rpc/src/utils.ts
+++ b/packages/datasource-rpc/src/utils.ts
@@ -8,16 +8,15 @@ export function getAuthoriztionHeaders(authSecret: string) {
   return { X_SIGNATURE: token, X_TIMESTAMP: timeStamp };
 }
 
-export function appendHeaders(req, authSecret: string, caller?: Caller) {
-  req.set(getAuthoriztionHeaders(authSecret));
-
-  req.set('Content-Type', 'application/json');
-
-  if (caller) req.set('forest_caller', JSON.stringify(caller));
-}
-
 export function toCamelCase(str: string): string {
   return str.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase());
+}
+
+export function toSnakeCase(str: string): string {
+  return str
+    .replace(/([A-Z])/g, '_$1')
+    .replace(/^_/, '')
+    .toLowerCase();
 }
 
 export function toPascalCase(str: string) {
@@ -48,4 +47,29 @@ export function keysToCamel(obj: any) {
   }
 
   return obj;
+}
+
+export function keysToSnake(obj: any) {
+  if (Array.isArray(obj)) {
+    return obj.map(v => keysToSnake(v));
+  }
+
+  if (obj !== null && typeof obj === 'object') {
+    return Object.entries(obj).reduce((acc, [key, value]) => {
+      const newKey = toSnakeCase(key);
+      acc[newKey] = keysToSnake(value);
+
+      return acc;
+    }, {});
+  }
+
+  return obj;
+}
+
+export function appendHeaders(req, authSecret: string, caller?: Caller) {
+  req.set(getAuthoriztionHeaders(authSecret));
+
+  req.set('Content-Type', 'application/json');
+
+  if (caller) req.set('forest_caller', JSON.stringify(keysToSnake(caller)));
 }

--- a/packages/datasource-rpc/test/utils.test.ts
+++ b/packages/datasource-rpc/test/utils.test.ts
@@ -1,0 +1,45 @@
+import { keysToCamel, keysToSnake } from '../src/utils';
+
+describe('utils', () => {
+  describe('keysToSnake', () => {
+    it('converts top-level camelCase keys to snake_case', () => {
+      expect(keysToSnake({ firstName: 'a', lastName: 'b' })).toEqual({
+        first_name: 'a',
+        last_name: 'b',
+      });
+    });
+
+    it('recurses into nested objects and arrays', () => {
+      const input = {
+        conditionTree: {
+          aggregator: 'And',
+          conditions: [{ fieldName: 'name', matchValue: 'X' }],
+        },
+        searchExtended: true,
+      };
+
+      expect(keysToSnake(input)).toEqual({
+        condition_tree: {
+          aggregator: 'And',
+          conditions: [{ field_name: 'name', match_value: 'X' }],
+        },
+        search_extended: true,
+      });
+    });
+
+    it('leaves non-object values untouched', () => {
+      expect(keysToSnake(null)).toBeNull();
+      expect(keysToSnake(undefined)).toBeUndefined();
+      expect(keysToSnake('helloWorld')).toBe('helloWorld');
+      expect(keysToSnake(42)).toBe(42);
+    });
+  });
+
+  describe('keysToCamel', () => {
+    it('round-trips with keysToSnake', () => {
+      const input = { firstName: 'a', nested: { someValue: 1 }, list: [{ deepKey: 'x' }] };
+
+      expect(keysToCamel(keysToSnake(input))).toEqual(input);
+    });
+  });
+});


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix RPC datasource requests to send snake_case keys for Ruby compatibility
- Adds `toSnakeCase` and `keysToSnake` utilities in [`utils.ts`](https://github.com/ForestAdmin/forestadmin-experimental/pull/219/files#diff-6769f9fcae8a42c12d1f92bf378f17f1b578f4f142c75a17507f4a6940090fdd) to recursively convert object keys from camelCase to snake_case.
- Applies `keysToSnake` to filter, aggregation, and action payload objects before sending requests to `/list`, `/update`, `/delete`, `/aggregate`, `/action-execute`, and `/action-form` endpoints.
- Also applies `keysToSnake` to the `forest_caller` header value.
- Behavioral Change: All outgoing RPC request bodies and the `forest_caller` header now use snake_case keys instead of camelCase.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6c81fa3.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->