### PR TITLE
fix(rpc agent): handle properly cross rpc relations

### DIFF
--- a/packages/rpc-agent/src/agent.ts
+++ b/packages/rpc-agent/src/agent.ts
@@ -3,7 +3,12 @@ import type { RpcSchema } from './types';
 import { Agent, AgentOptions } from '@forestadmin/agent';
 import { ForestAdminHttpDriverServices } from '@forestadmin/agent/dist/services';
 import { DataSourceOptions, TCollectionName, TSchema } from '@forestadmin/datasource-customizer';
-import { Collection, DataSource, DataSourceFactory } from '@forestadmin/datasource-toolkit';
+import {
+  Collection,
+  DataSource,
+  DataSourceFactory,
+  RelationSchema,
+} from '@forestadmin/datasource-toolkit';
 import { createHash } from 'crypto';
 import fs from 'fs/promises';
 
@@ -122,11 +127,11 @@ export default class RpcAgent<S extends TSchema = TSchema> extends Agent<S> {
   }
 
   buildSchema(dataSource: DataSource): RpcSchema {
-    const rpcRelations = {};
-    const collections = [];
+    const rpcRelations: RpcSchema['rpc_relations'] = {};
+    const collections: RpcSchema['collections'] = [];
 
     dataSource.collections.forEach(collection => {
-      const relations = {};
+      const relations: Record<string, RelationSchema> = {};
 
       if (this.rpcCollections.includes(collection.name)) {
         Object.entries(collection.schema.fields).forEach(([name, field]) => {
@@ -134,11 +139,11 @@ export default class RpcAgent<S extends TSchema = TSchema> extends Agent<S> {
             relations[name] = keysToSnake(field);
           }
         });
-
-        if (Object.keys(relations).length > 0) rpcRelations[collection.name] = relations;
       } else {
         collections.push(this.buildCollection(collection, relations));
       }
+
+      if (Object.keys(relations).length > 0) rpcRelations[collection.name] = relations;
     });
 
     return {

--- a/packages/rpc-agent/test/agent.test.ts
+++ b/packages/rpc-agent/test/agent.test.ts
@@ -23,6 +23,33 @@ function buildCollectionFixture(actionSchema: Record<string, unknown>) {
   } as any;
 }
 
+function buildColumn(operators: string[] = ['Equal']) {
+  return { type: 'Column', filterOperators: new Set(operators) };
+}
+
+function buildRelation(foreignCollection: string) {
+  return { type: 'ManyToOne', foreignCollection, foreignKey: `${foreignCollection}Id` };
+}
+
+function buildSchemaCollection(name: string, fields: Record<string, unknown>) {
+  return {
+    name,
+    schema: {
+      fields,
+      actions: {},
+      aggregationCapabilities: {
+        supportedDateOperations: new Set<string>(),
+        supportGroups: false,
+      },
+      countable: false,
+      searchable: false,
+      charts: [],
+      segments: [],
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
 describe('RpcAgent.buildCollection', () => {
   it('serialises generateFile as is_generate_file so Ruby main agents read it natively', () => {
     const agent = createAgent();
@@ -40,5 +67,81 @@ describe('RpcAgent.buildCollection', () => {
       is_generate_file: true,
       description: 'export',
     });
+  });
+});
+
+describe('RpcAgent.buildSchema', () => {
+  function createAgentWithRpcCollections(rpcCollections: string[]): RpcAgent {
+    const agent = createAgent();
+    (agent as unknown as { rpcCollections: string[] }).rpcCollections = rpcCollections;
+
+    return agent;
+  }
+
+  function buildDataSource(collections: unknown[]) {
+    return {
+      collections,
+      schema: { charts: [] },
+      nativeQueryConnections: {},
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+  }
+
+  // Non-regression: a NON-RPC collection holding a relation toward an RPC collection
+  // must be exposed in `rpc_relations`. The cross relation used to be computed in
+  // buildCollection then dropped because the registration lived inside the RPC branch only.
+  it('exposes cross relations from a non-RPC collection pointing to an RPC collection', () => {
+    const agent = createAgentWithRpcCollections(['Books']);
+
+    // Authors is a main (non-RPC) collection referencing the RPC collection Books.
+    const authors = buildSchemaCollection('Authors', {
+      id: buildColumn(),
+      myBook: buildRelation('Books'),
+    });
+    const books = buildSchemaCollection('Books', { id: buildColumn() });
+
+    const schema = agent.buildSchema(buildDataSource([authors, books]));
+
+    expect(schema.rpc_relations.Authors).toBeDefined();
+    expect(schema.rpc_relations.Authors.myBook).toMatchObject({
+      type: 'ManyToOne',
+      foreign_collection: 'Books',
+    });
+
+    // The cross relation is stripped from the exposed collection fields.
+    const exposedAuthors = schema.collections.find(c => c.name === 'Authors');
+    expect(exposedAuthors.fields).toHaveProperty('id');
+    expect(exposedAuthors.fields).not.toHaveProperty('myBook');
+  });
+
+  it('keeps exposing relations from an RPC collection toward non-RPC collections', () => {
+    const agent = createAgentWithRpcCollections(['Books']);
+
+    const books = buildSchemaCollection('Books', {
+      id: buildColumn(),
+      author: buildRelation('Authors'),
+    });
+    const authors = buildSchemaCollection('Authors', { id: buildColumn() });
+
+    const schema = agent.buildSchema(buildDataSource([books, authors]));
+
+    expect(schema.rpc_relations.Books).toBeDefined();
+    expect(schema.rpc_relations.Books.author).toMatchObject({
+      type: 'ManyToOne',
+      foreign_collection: 'Authors',
+    });
+    // The RPC collection itself is not added to the exposed `collections` array.
+    expect(schema.collections.find(c => c.name === 'Books')).toBeUndefined();
+  });
+
+  it('omits collections without cross relations from rpc_relations', () => {
+    const agent = createAgentWithRpcCollections(['Books']);
+
+    const books = buildSchemaCollection('Books', { id: buildColumn() });
+    const authors = buildSchemaCollection('Authors', { id: buildColumn() });
+
+    const schema = agent.buildSchema(buildDataSource([books, authors]));
+
+    expect(schema.rpc_relations).toEqual({});
   });
 });


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix cross-RPC relation assignment in `RpcAgent.buildSchema`
In [agent.ts](https://github.com/ForestAdmin/forestadmin-experimental/pull/220/files#diff-0e8d5c13e339e8ad9b93fffe734576fd36480a98aa1a3c9901192eb92f832eef), the `rpcRelations` map entry for a collection was only being populated inside the RPC-collection branch, causing cross-RPC relations to be dropped. The fix moves the assignment outside that branch so all non-empty relation maps are included regardless of collection type.

<!-- Macroscope's changelog starts here -->
#### Changes since #220 opened

- Added test helper functions for constructing schema components [0429318]
- Added test suite for `RpcAgent.buildSchema` to validate cross-RPC relation handling [0429318]
<!-- Macroscope's changelog ends here -->

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 88be7bc.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->