### PR TITLE
fix(datasource-rpc): prevent infinite loop in reconciliateRpc when using rename

### DIFF
--- a/packages/datasource-rpc/src/plugins.ts
+++ b/packages/datasource-rpc/src/plugins.ts
@@ -8,10 +8,10 @@ import RpcDataSource from './datasource';
 function getRealDatasource(datasource) {
   let d = datasource;
 
-  while (datasource instanceof DataSourceDecorator) {
+  while (d instanceof DataSourceDecorator) {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    d = datasource.childDataSource;
+    d = d.childDataSource;
   }
 
   return d;
@@ -39,7 +39,7 @@ export function reconciliateRpc(dz, _, options?: PluginOptions) {
       });
 
       Object.entries(d.rpcRelations).forEach(([name, relations]) => {
-        const cz: CollectionCustomizer = dz.getCollection(name);
+        const cz: CollectionCustomizer = dz.getCollection(getCollectionName(name, options?.rename));
 
         Object.entries(relations).forEach(([relationName, relationDefinition]) => {
           const foreignCollection = getCollectionName(

--- a/packages/datasource-rpc/src/plugins.ts
+++ b/packages/datasource-rpc/src/plugins.ts
@@ -20,7 +20,9 @@ function getRealDatasource(datasource) {
 function getCollectionName(collectionName: string, rename?: PluginOptions['rename']) {
   if (!rename) return collectionName;
 
-  return typeof rename === 'function' ? rename(collectionName) : rename[collectionName];
+  const renamed = typeof rename === 'function' ? rename(collectionName) : rename[collectionName];
+
+  return renamed ?? collectionName;
 }
 
 // eslint-disable-next-line import/prefer-default-export

--- a/packages/datasource-rpc/test/plugins.test.ts
+++ b/packages/datasource-rpc/test/plugins.test.ts
@@ -1,0 +1,80 @@
+import { DataSourceDecorator } from '@forestadmin/datasource-toolkit';
+
+import RpcDataSource from '../src/datasource';
+import { reconciliateRpc } from '../src/plugins';
+
+function buildRpcDataSource(rpcRelations = {}) {
+  const logger = jest.fn();
+  const options = { uri: 'http://localhost', authSecret: 'secret' };
+  const introspection = {
+    collections: [],
+    charts: [],
+    rpcRelations,
+    nativeQueryConnections: [],
+    etag: 'x',
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return new RpcDataSource(logger as any, options, introspection as any);
+}
+
+function buildCustomizer() {
+  const cz = {
+    disableSearch: jest.fn(),
+    addManyToOneRelation: jest.fn(),
+    addOneToManyRelation: jest.fn(),
+    addOneToOneRelation: jest.fn(),
+    addManyToManyRelation: jest.fn(),
+  };
+
+  const dz = {
+    compositeDataSource: { dataSources: [] as unknown[] },
+    getCollection: jest.fn(() => cz),
+  };
+
+  return { dz, cz };
+}
+
+describe('reconciliateRpc', () => {
+  // Regression: getRealDatasource used to loop on the unchanging parameter instead of the
+  // walked variable, hanging the event loop when the RPC datasource was wrapped by rename.
+  it('terminates when the RPC datasource is wrapped in a DataSourceDecorator (rename)', () => {
+    const rpc = buildRpcDataSource();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const wrapped = new DataSourceDecorator(rpc as any, class {} as any);
+    const { dz } = buildCustomizer();
+    dz.compositeDataSource.dataSources = [wrapped];
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(() => reconciliateRpc(dz as any, undefined, {})).not.toThrow();
+  });
+
+  it('applies the rename to the relation origin collection and its foreign collection', () => {
+    const rpc = buildRpcDataSource({
+      books: {
+        author: {
+          type: 'ManyToOne',
+          foreignCollection: 'authors',
+          foreignKey: 'author_id',
+          foreignKeyTarget: 'id',
+        },
+      },
+    });
+    const { dz, cz } = buildCustomizer();
+    dz.compositeDataSource.dataSources = [rpc];
+
+    reconciliateRpc(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      dz as any,
+      undefined,
+      { rename: (name: string) => `pre_${name}` },
+    );
+
+    expect(dz.getCollection).toHaveBeenCalledWith('pre_books');
+    expect(cz.addManyToOneRelation).toHaveBeenCalledWith(
+      'author',
+      'pre_authors',
+      expect.objectContaining({ foreignCollection: 'authors' }),
+    );
+  });
+});

--- a/packages/datasource-rpc/test/plugins.test.ts
+++ b/packages/datasource-rpc/test/plugins.test.ts
@@ -77,4 +77,37 @@ describe('reconciliateRpc', () => {
       expect.objectContaining({ foreignCollection: 'authors' }),
     );
   });
+
+  // A partial object-map must leave unlisted collections under their original name,
+  // not resolve them to `undefined`.
+  it('falls back to the original name for collections absent from an object rename map', () => {
+    const rpc = buildRpcDataSource({
+      books: {
+        author: {
+          type: 'ManyToOne',
+          foreignCollection: 'authors',
+          foreignKey: 'author_id',
+          foreignKeyTarget: 'id',
+        },
+      },
+    });
+    const { dz, cz } = buildCustomizer();
+    dz.compositeDataSource.dataSources = [rpc];
+
+    reconciliateRpc(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      dz as any,
+      undefined,
+      { rename: { authors: 'writers' } },
+    );
+
+    // `books` is not in the map -> keeps its own name; `authors` is remapped.
+    expect(dz.getCollection).toHaveBeenCalledWith('books');
+    expect(dz.getCollection).not.toHaveBeenCalledWith(undefined);
+    expect(cz.addManyToOneRelation).toHaveBeenCalledWith(
+      'author',
+      'writers',
+      expect.objectContaining({ foreignCollection: 'authors' }),
+    );
+  });
 });


### PR DESCRIPTION
## Problem

Calling `agent.addDataSource(createRpcDataSource(...), { rename })` on a gateway agent consuming an RPC datasource **hangs the process indefinitely at 100% CPU** during startup, with the event loop fully blocked. Removing `rename` makes the same setup start correctly.

## Root cause

`getRealDatasource` in `plugins.ts` unwraps decorator layers with:

```js
let d = datasource;
while (datasource instanceof DataSourceDecorator) {  // tests `datasource` — never reassigned
  d = datasource.childDataSource;                     // walks `d` instead
}
```

When `rename` is set, `addDataSource` wraps the RPC datasource in a `RenameCollectionDataSourceDecorator`, so `datasource instanceof DataSourceDecorator` is permanently `true` → flat infinite loop. Without `rename` the datasource is a raw `RpcDataSource` (not a decorator), the loop never enters, and startup succeeds — which is exactly why dropping `rename` "fixes" it.

It's a flat loop, not recursion, so there's no stack-overflow error — matching the reported symptom of a silent 100% CPU hang.

## Fix

- Loop on `d` instead of `datasource` (2 lines).
- Apply `rename` to the relation **origin** collection lookup — a latent bug that surfaces the moment the loop is fixed: the `disableSearch` path already renamed, but the relation path used the raw name and would throw "collection not found".

## Tests

Adds `test/plugins.test.ts`:
- terminates when the RPC datasource is wrapped by rename (regression guard for the hang)
- applies rename to both the relation origin and foreign collections

Verified the guard fails against the original code (the termination test hangs the jest worker — same mechanism as prod), and the full `datasource-rpc` suite is green (11/11).

## Note

The equivalent Ruby port (`agent-ruby/packages/forest_admin_datasource_rpc`) is **not affected** — its `get_datasource` reassigns the loop variable directly and it already renames the relation origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix infinite loop in `reconciliateRpc` when using rename with `DataSourceDecorator`
> - Fixes an infinite loop in `getRealDatasource` by iterating on a local variable instead of the original `datasource` parameter, so the loop terminates when it reaches the base datasource.
> - Fixes `getCollectionName` to fall back to the original collection name when rename is an object-map and the key is absent, instead of returning `undefined`.
> - Updates `reconciliateRpc` to apply rename resolution when looking up origin collections, consistent with how renaming is applied elsewhere.
> - Adds unit tests in [plugins.test.ts](https://github.com/ForestAdmin/forestadmin-experimental/pull/221/files#diff-06288f53d75ad498ee1be915b4108020a69e735cc425c723c48fbfaf747c750f) covering loop termination, rename application, and object-map fallback behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 971ee1a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->